### PR TITLE
chore: Move postcss to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"type": "git",
 		"url": "https://github.com/jonathantneal/bootstrap-fonts-complete.git"
 	},
-	"dependencies": {
+	"devDependencies": {
 		"postcss": "^4.1.16"
 	}
 }


### PR DESCRIPTION
Since the package contains no runnable code, it looks like PostCSS is only needed during development to update the JSON files.
Avoid postcss-font-magician pulling too many PostCSS versions, similar idea to https://github.com/jonathantneal/google-fonts-complete/pull/23